### PR TITLE
Added support for PHPCI

### DIFF
--- a/src/HMLB/VW/SecretSoftware.php
+++ b/src/HMLB/VW/SecretSoftware.php
@@ -27,6 +27,7 @@ class SecretSoftware
         'JENKINS_URL',
         'HUDSON_URL',
         'bamboo.buildKey',
+        'PHPCI',
     );
 
     public function __construct(array $additionalEnvVariables = array())


### PR DESCRIPTION
Wouldn't want to miss out PHPCI. Having tests fail there when they obviously should pass is not right.

https://www.phptesting.org

Where the env is set:
https://github.com/Block8/PHPCI/blob/3a6008db53e6a8fe38b19deed65f2c182896a791/PHPCI/Helper/BuildInterpolator.php#L61
