### PR TITLE
Mentions CodeShip also being supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Currently detects :
 * TravisCI
 * Bamboo
 * CircleCI
+* CodeShip
 * GitlabCI
 * Go CD
 * Hudson


### PR DESCRIPTION
As you can see [in their documentation](https://codeship.com/documentation/continuous-integration/set-environment-variables/) the [Codeship CI](https://codeship.com/) sets the `CI` environment variable.

Thus it is also supported.

The documentation didn't mention that, so now it does :grin: 
