### PR TITLE
Adds Buildkite to the list of examinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Currently detects :
 * Jenkins
 * PHPCI
 * TeamCity
-
+* Buildkite
 
 Other CI tools using environment variables like 'BUILD_ID' would be detected as well.
 

--- a/src/HMLB/VW/SecretSoftware.php
+++ b/src/HMLB/VW/SecretSoftware.php
@@ -29,6 +29,7 @@ class SecretSoftware
         'bamboo.buildKey',
         'PHPCI',
         'GOCD_SERVER_HOST',
+        'BUILDKITE',
     );
 
     public function __construct(array $additionalEnvVariables = array())


### PR DESCRIPTION
We're a big fan of green builds, even if the tests say otherwise. This adds [Buildkite](https://buildkite.com/) support to the list of secret examinators.
