### PR TITLE
Adds wercker to list of supported CI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Currently detects :
 * Jenkins
 * PHPCI
 * TeamCity
+* Wercker
 
 
 Other CI tools using environment variables like 'BUILD_ID' would be detected as well.


### PR DESCRIPTION
Wercker uses `CI` as the build detection variable.

See http://old-devcenter.wercker.com/articles/steps/variables.html