### PR TITLE
Fixes to CI-Configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
     - php: "5.3"
       dist: precise
 
-#before_script:
+before_script:
 #  - composer self-update
-#  - composer install -n
+  - composer install #-n
 
 script: vendor/bin/phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
 language: php
-
+dist: trusty
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
   - hhvm
   - nightly
+matrix:
+  include:
+    - php: "5.3"
+      dist: precise
 
-before_script:
-  - composer self-update
-  - composer install -n
+#before_script:
+#  - composer self-update
+#  - composer install -n
 
-script: phpunit
+script: vendor/bin/phpunit
 
-notifications:
-  email:
-    - system+travis-ci@hmlb.fr
+#notifications:
+ # email:
+  #  - system+travis-ci@hmlb.fr

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,10 @@ matrix:
       dist: precise
 
 before_script:
-#  - composer self-update
-  - composer install #-n
+  - composer install
 
 script: vendor/bin/phpunit
 
-#notifications:
- # email:
-  #  - system+travis-ci@hmlb.fr
+notifications:
+  email:
+    - system+travis-ci@hmlb.fr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@ shallow_clone: false
 platform: 'x86'
 clone_folder: C:\projects\phpunit-vw
 init:
-  - cinst php sqlite
+  - cinst php --params '"/InstallDir:C:\tools\php"""'
+  - cinst sqlite
   - SET PATH=C:\tools\php\;%PATH%
-  - SET PATH=C:\tools\SQLite\;%PATH%
 install:
   - cd c:\tools\php
   - copy php.ini-production php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ shallow_clone: false
 platform: 'x86'
 clone_folder: C:\projects\phpunit-vw
 init:
-  - cinst php --params '"/InstallDir:C:\tools\php"""'
+  - cinst php --params '"/InstallDir:C:\tools\php"'
   - cinst sqlite
   - SET PATH=C:\tools\php\;%PATH%
 install:


### PR DESCRIPTION
Travis:
- PHP 5.3 is no longer readily avaible, so adjusted inclusion

Appsurveyor
- PHP is no longer installed in the expected directory by default, so adjusted installation